### PR TITLE
fix: display prompt message only when folder doesn't exist

### DIFF
--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -19,7 +19,6 @@ func ReadArgsAndValidate() {
 		return
 	}
 
-	err = file.Generate(fileName, fileExtension)
 
 	isFileExists, err := checkDirectoryExists(fileName)
 	if isFileExists {


### PR DESCRIPTION
@AliAkberAakash  Prompt message bug fixed https://github.com/AliAkberAakash/file_tree/issues/18